### PR TITLE
outline.py: fix for Python3

### DIFF
--- a/outlines.py
+++ b/outlines.py
@@ -41,7 +41,7 @@ for glyph in font.glyphs():
 		elif strokeType[glyph.glyphname][0] == 'circular':
 			glyph.stroke("circular",strokeType[glyph.glyphname][1],"square","round")
 		else: # this should not occur
-			raise ValueError, "unsupported stroke type"
+			raise ValueError("unsupported stroke type")
 
 font.selection.all()
 font.addExtrema();font.round()


### PR DESCRIPTION
``outline.py`` fails with a syntax error if Fontforge is linked against Python3, e. g.:

    $ ldd $(which fontforge) | grep python
            libpython3.6m.so.1.0 => /usr/lib/libpython3.6m.so.1.0 (0x00007fa9d589d000)
